### PR TITLE
Fix JSON request data

### DIFF
--- a/airbrake/airbrake.py
+++ b/airbrake/airbrake.py
@@ -43,8 +43,8 @@ class AirbrakeErrorHandler(logging.Handler):
         }
 
         try:
-            self.requests['json'] = request.json
-        except Exception as exc:
+            self.request['json'] = request.json
+        except AttributeError:
             pass # Werkzeug couldn't parse json, ignored
 
     def emit(self, exception, exc_info=None):

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -17,6 +17,7 @@ class UnitTests(BaseTestCase):
 
         # check Flask request object info:
         assert_is_not_none(self.client.request)
+        assert_is_not_none(self.client.request['json'])
 
     def test_generate_xml(self):
         xml = self.client._generate_xml(exception=Exception('hola exception'))


### PR DESCRIPTION
There was a typo in the code (`self.requests` instead of `self.request`) that prevented JSON request data to be reported at all. This pull request fixes the problem, and makes the except block more specific to make sure it won't mask any other errors.
